### PR TITLE
Travis ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "8"
+  - "9"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 node_js:
   - "8"
   - "9"
+sudo: required
+addons:
+  chrome: stable

--- a/__specs__/integration/chrome/client.spec.js
+++ b/__specs__/integration/chrome/client.spec.js
@@ -3,7 +3,7 @@ const {expect} = require('chai')
 const awb = require('../../../awb')
 const conf = {
   remote: false,
-  directConnect: false,
+  directConnect: true,
   desiredCapabilities: {
     javascriptEnabled: true,
     acceptSslCerts: true,
@@ -11,8 +11,8 @@ const conf = {
     browserName: 'chrome',
     chromeOptions: {args: ['--headless']}
   },
-  host: 'localhost',
-  port: 4444,
+  // host: 'localhost',
+  // port: 4444,
   timeout: 25000
 }
 

--- a/__specs__/integration/chrome/client.spec.js
+++ b/__specs__/integration/chrome/client.spec.js
@@ -8,7 +8,8 @@ const conf = {
     javascriptEnabled: true,
     acceptSslCerts: true,
     platform: 'ANY',
-    browserName: 'chrome'
+    browserName: 'chrome',
+    chromeOptions: {args: ['--headless']}
   },
   host: 'localhost',
   port: 4444,

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     },
     "scripts": {
         "lint": "eslint lib/** --ext .js",
-        "pretest": "./bin/awb standalone gecko chrome",
+        "pretest": "./bin/awb standalone chrome",
         "test": "npm run integration-chrome",
         "integration-chrome": "mocha --timeout 60000 $(find ./__specs__/integration/chrome -path '*.spec.js')",
         "integration-chrome:watch": "mocha --timeout 60000 -w --harmony --trace-deprecation $(find ./__specs__/integration/chrome -path '*.spec.js')",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     },
     "scripts": {
         "lint": "eslint lib/** --ext .js",
+        "pretest": "./bin/awb standalone gecko chrome",
+        "test": "npm run integration-chrome",
         "integration-chrome": "mocha --timeout 60000 $(find ./__specs__/integration/chrome -path '*.spec.js')",
         "integration-chrome:watch": "mocha --timeout 60000 -w --harmony --trace-deprecation $(find ./__specs__/integration/chrome -path '*.spec.js')",
         "integration-firefox": "mocha --timeout 60000 $(find ./__specs__/integration/firefox -path '*.spec.js')",


### PR DESCRIPTION
- Switched to use DirectConnect and headless chrome for unit tests
- added `test` and `pretest` scripts (for travis)
- Added travis yml file with node 8 and 9 config. Chrome installation included